### PR TITLE
Optimize jaccard by using the union-intersection cardinals theorem

### DIFF
--- a/uploadcsv/management/commands/set_implementation.py
+++ b/uploadcsv/management/commands/set_implementation.py
@@ -9,7 +9,7 @@ def jaccard(set1, set2):
         set1 and set2 are the set of shingles of the strings to compare
     """
     x = len(set1.intersection(set2))
-    y = len(set1.union(set2))
+    y = len(set1) + len(set2) - x
     res = x / float(y)
     return res
 


### PR DESCRIPTION
Given that len(A) + len(B) = len(intersection(A, B)) + len(union(A, B)), we can avoid unnecessary computation by calculating len(union(A,B)) as a function of len(A), len(B) and len(intersection(A, B)).
This results in a significant improvement, by a constant factor, in the overall running time of the algorithm.
